### PR TITLE
[초기세팅] CI/CD 구축

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Cloudflare Pages Deployment
+# Deployment - main push 시,
+on:
+    push:
+        branches: [main]
+    # pull_request:
+    #     types:
+    #         - closed
+
+    #     branches: [main]
+
+env:
+    CI: false
+
+permissions:
+    contents: read
+    deployments: write
+    pull-requests: write
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        name: Publish to Cloudflare Pages
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Build
+              run: yarn install && yarn build
+
+            - name: Publish to Cloudflare Pages
+              uses: cloudflare/pages-action@v1
+              id: cloudflare
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  projectName: sodong
+                  directory: dist
+                  gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Comment PR
+              uses: mshick/add-pr-comment@v2
+              with:
+                  message-id: cloudflare-deploy
+                  message: |
+                      ### 🚀 Deploy Success! - [https://sodong.pages.dev/](https://sodong.pages.dev/)
+
+                      |  Name | Link |
+                      |---------------------------------|------------------------|
+                      |<span aria-hidden="true">🔨</span> Latest commit | ${{ github.sha }} |
+                      |<span aria-hidden="true">🔍</span> Latest deploy log | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |
+                      |<span aria-hidden="true">🖇️</span> Deploy Preview Url | [${{ steps.cloudflare.outputs.url }}](${{ steps.cloudflare.outputs.url }}) |
+                      |<span aria-hidden="true">🌳</span> Environment | ${{ steps.cloudflare.outputs.environment }} |
+                      ---

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,54 @@
+name: Cloudflare Pages Preview
+# Preview - main, develop PR open 시
+on:
+    pull_request:
+        types:
+            - opened
+            - reopened
+            - synchronize
+
+        branches: [main, develop]
+
+env:
+    CI: false
+
+permissions:
+    contents: read
+    deployments: write
+    pull-requests: write
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        name: Publish to Cloudflare Pages
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Build
+              run: yarn install && yarn build
+
+            - name: Publish to Cloudflare Pages
+              uses: cloudflare/pages-action@v1
+              id: cloudflare
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  projectName: sodong
+                  directory: dist
+                  gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Comment PR
+              uses: mshick/add-pr-comment@v2
+              with:
+                  message-id: cloudflare-preview
+                  message: |
+                      ### 👀 Preview Success! 
+
+                      |  Name | Link |
+                      |---------------------------------|------------------------|
+                      |<span aria-hidden="true">🔨</span> Latest commit | ${{ github.sha }} |
+                      |<span aria-hidden="true">🔍</span> Latest deploy log | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |
+                      |<span aria-hidden="true">🖇️</span> Deploy Preview Url | [${{ steps.cloudflare.outputs.url }}](${{ steps.cloudflare.outputs.url }}) |
+                      |<span aria-hidden="true">🌳</span> Environment | ${{ steps.cloudflare.outputs.environment }} |
+                      ---


### PR DESCRIPTION
## 🪄 Issue Number
- close #5 

## 🏆 Details
- [x] `production` 배포 - main 브랜치 push 시
- [x] `preview` 배포 - main, develop 브랜치 pull request opened 시

## ✅ Need Review
- cloudflare pages로 production, preview 배포 세팅하였습니다. 

## 📚 Reference
[https://github.com/cloudflare/pages-action](https://github.com/cloudflare/pages-action)

<img width="350"  alt="image" src="https://github.com/user-attachments/assets/19bbe239-bfc5-47af-92dc-7ff0fff343bc" />

Organization의 레포는 무료로 배포가 불가하여 fork 해온 레포에서 별도의 처리가 필요함. 따라서, 세팅이 어렵지 않으므로 Cloudflare 기반으로 프리뷰, 개발, 프로덕션 배포를 커스텀하여 사용하는 방식으로 결정.
