### PR TITLE
[포스트생성] 포스팅 상태 아카이빙 및 이미지 업로드 통신

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -11,12 +11,18 @@ export const cleanHeaderInstance = axios.create({
   headers: {},
 });
 
+// [이미지 업로드]
+// 8002 포트번호 다른 이유로 인스턴스 생성
+export const imageinstance = axios.create({
+  baseURL: import.meta.env.VITE_APP_BASE_URL,
+  withCredentials: false,
+  headers: {},
+});
+
 export const instance = axios.create({
   baseURL: import.meta.env.VITE_APP_BASE_URL,
-  withCredentials: true,
-  headers: {
-    Authorization: `${getAccessTokenLocalStorage()}`,
-  },
+  withCredentials: false,
+  headers: {},
 });
 
 export function get<T>(...args: Parameters<typeof instance.get>) {
@@ -28,7 +34,7 @@ export function post<T>(...args: Parameters<typeof instance.post>) {
 }
 
 export function put<T>(...args: Parameters<typeof instance.put>) {
-  return instance.put<T>(...args);
+  return imageinstance.put<T>(...args);
 }
 
 export function patch<T>(...args: Parameters<typeof instance.patch>) {
@@ -38,3 +44,7 @@ export function patch<T>(...args: Parameters<typeof instance.patch>) {
 export function del<T>(...args: Parameters<typeof instance.delete>) {
   return instance.delete<T>(...args);
 }
+
+// export function put<T>(...args: Parameters<typeof instance.put>) {
+//   return instance.put<T>(...args);
+// }

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -21,7 +21,7 @@ export const imageinstance = axios.create({
 
 export const instance = axios.create({
   baseURL: import.meta.env.VITE_APP_BASE_URL,
-  withCredentials: false,
+  withCredentials: true,
   headers: {},
 });
 

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -14,7 +14,7 @@ export const cleanHeaderInstance = axios.create({
 // [이미지 업로드]
 // 8002 포트번호 다른 이유로 인스턴스 생성
 export const imageinstance = axios.create({
-  baseURL: import.meta.env.VITE_APP_BASE_URL,
+  baseURL: import.meta.env.VITE_APP_IMG_URL,
   withCredentials: false,
   headers: {},
 });

--- a/src/components/PostNew/PostFooter/PostFooter.tsx
+++ b/src/components/PostNew/PostFooter/PostFooter.tsx
@@ -2,16 +2,23 @@ import styled from 'styled-components';
 import ButtonFill from '../../common/Button/ButtonFill/ButtonFill';
 import ButtonPrev from '../../common/Button/ButtonPrev/ButtonPrev';
 interface PostFooterProps {
-  onNext: VoidFunction;
+  setStep: React.Dispatch<React.SetStateAction<number>>;
+  onClickBackBtn: (stemNum: number | undefined) => void;
+  onNext?: VoidFunction;
+  isActivated?: boolean;
+  stepNum?: number | undefined;
 }
 
-export default function PostFooter(props: PostFooterProps) {
-  const { onNext } = props;
+export default function PostFooter({ setStep, onClickBackBtn, stepNum }: PostFooterProps) {
+  const onClick = () => {
+    setStep((prev) => prev + 1);
+  };
+
 
   return (
     <PostFooterContainer>
-      <ButtonPrev title='이전' width='7.6rem' />
-      <ButtonFill title='다음' width='11.5rem' onClick={onNext} />
+      <ButtonPrev title='이전' width='7.6rem' onClick={() => onClickBackBtn(stepNum)} />
+      <ButtonFill title='다음' width='11.5rem' onClick={onClick} />
     </PostFooterContainer>
   );
 }

--- a/src/components/PostNew/Step1/Step1.tsx
+++ b/src/components/PostNew/Step1/Step1.tsx
@@ -1,20 +1,20 @@
 import { useState } from 'react';
 import styled from 'styled-components';
-import PostFooter from '../PostFooter/PostFooter';
 import { CheckIcon } from '../../../assets/svg';
 import kakao from '../../../assets/Image/kakao.png';
 import carrot from '../../../assets/Image/carrot.png';
 import kakaoMap from '../../../assets/Image/kakaoMap.png';
 import insta from '../../../assets/Image/Instagram.png';
 import Step1Title from './Step1Title/Step1Title';
+import { useOnboardingContext } from '../../../context/PostNew/PonstNewContext';
 
-interface NameInputProps {
-  onNext: VoidFunction;
-}
+// interface NameInputProps {
+//   onNext: VoidFunction;
+// }
 
-export default function Step1(props: NameInputProps) {
-  const { onNext } = props;
+export default function Step1() {
   const [selectedSNS, setSelectedSNS] = useState<string | null>(null);
+  const { updatePostInfo } = useOnboardingContext(); // OnboardingContext에서 정보 가져오기
 
   const snsOptions = [
     { name: '인스타그램', icon: insta },
@@ -25,6 +25,7 @@ export default function Step1(props: NameInputProps) {
 
   const handleSelectSNS = (sns: string) => {
     setSelectedSNS(sns === selectedSNS ? null : sns);
+    updatePostInfo({ postingChannel: sns });
   };
 
   return (
@@ -47,7 +48,6 @@ export default function Step1(props: NameInputProps) {
           ))}
         </SNSOptionContainer>
       </PostTitleContainer>
-      <PostFooter onNext={onNext} />
     </>
   );
 }

--- a/src/components/PostNew/Step1/Step1.tsx
+++ b/src/components/PostNew/Step1/Step1.tsx
@@ -6,7 +6,7 @@ import carrot from '../../../assets/Image/carrot.png';
 import kakaoMap from '../../../assets/Image/kakaoMap.png';
 import insta from '../../../assets/Image/Instagram.png';
 import Step1Title from './Step1Title/Step1Title';
-import { useOnboardingContext } from '../../../context/PostNew/PonstNewContext';
+import { useOnboardingContext } from '../../../context/PostNew/PostNewContext';
 
 export default function Step1() {
   const { onboardingInfo, updatePostInfo } = useOnboardingContext();

--- a/src/components/PostNew/Step1/Step1.tsx
+++ b/src/components/PostNew/Step1/Step1.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 import { CheckIcon } from '../../../assets/svg';
 import kakao from '../../../assets/Image/kakao.png';
@@ -22,13 +22,12 @@ export default function Step1() {
   ];
 
   const handleSelectSNS = (sns: string) => {
-    setSelectedSNS((prev) => (prev === sns ? null : sns));
-    updatePostInfo({ postingChannel: sns });
+    setSelectedSNS((prev) => {
+      const newSelectedSNS = prev === sns ? null : sns;
+      updatePostInfo({ postingChannel: newSelectedSNS });
+      return newSelectedSNS;
+    });
   };
-
-  useEffect(() => {
-    setSelectedSNS(onboardingInfo.postingChannel || null); // 이전 스텝에서 설정된 값이 있을 경우 업데이트
-  }, [onboardingInfo.postingChannel]);
 
   return (
     <>

--- a/src/components/PostNew/Step1/Step1.tsx
+++ b/src/components/PostNew/Step1/Step1.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { CheckIcon } from '../../../assets/svg';
 import kakao from '../../../assets/Image/kakao.png';
@@ -8,13 +8,11 @@ import insta from '../../../assets/Image/Instagram.png';
 import Step1Title from './Step1Title/Step1Title';
 import { useOnboardingContext } from '../../../context/PostNew/PonstNewContext';
 
-// interface NameInputProps {
-//   onNext: VoidFunction;
-// }
-
 export default function Step1() {
-  const [selectedSNS, setSelectedSNS] = useState<string | null>(null);
-  const { updatePostInfo } = useOnboardingContext(); // OnboardingContext에서 정보 가져오기
+  const { onboardingInfo, updatePostInfo } = useOnboardingContext();
+  const [selectedSNS, setSelectedSNS] = useState<string | null>(
+    onboardingInfo.postingChannel || null,
+  );
 
   const snsOptions = [
     { name: '인스타그램', icon: insta },
@@ -24,9 +22,13 @@ export default function Step1() {
   ];
 
   const handleSelectSNS = (sns: string) => {
-    setSelectedSNS(sns === selectedSNS ? null : sns);
+    setSelectedSNS((prev) => (prev === sns ? null : sns));
     updatePostInfo({ postingChannel: sns });
   };
+
+  useEffect(() => {
+    setSelectedSNS(onboardingInfo.postingChannel || null); // 이전 스텝에서 설정된 값이 있을 경우 업데이트
+  }, [onboardingInfo.postingChannel]);
 
   return (
     <>
@@ -43,7 +45,7 @@ export default function Step1() {
                 <img src={sns.icon} alt={sns.name} />
                 {sns.name}
               </ImgContainer>
-              {selectedSNS === sns.name && <CheckIcon style={{ width: '1.2rem' }} />}{' '}
+              {selectedSNS === sns.name && <CheckIcon style={{ width: '1.2rem' }} />}
             </SNSOption>
           ))}
         </SNSOptionContainer>
@@ -60,7 +62,6 @@ const ImgContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-
   gap: 1rem;
 
   img {
@@ -72,7 +73,6 @@ const SNSOptionContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-
   margin-top: 1.6rem;
   flex-direction: column;
   gap: 1rem;
@@ -82,13 +82,11 @@ const SNSOption = styled.div<{ selected: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
-
   padding: 0.5rem 1rem;
   border-radius: 8px;
   width: 19.9375rem;
   height: 4.375rem;
   cursor: pointer;
-
   ${({ theme }) => theme.fonts.subTitle};
   border: ${({ selected, theme }) => (selected ? `1px solid ${theme.colors.main}` : 'none')};
   box-shadow: 0px 1px 10px 0px rgba(0, 0, 0, 0.1);

--- a/src/components/PostNew/Step1/Step1.tsx
+++ b/src/components/PostNew/Step1/Step1.tsx
@@ -62,6 +62,10 @@ const ImgContainer = styled.div`
   align-items: center;
 
   gap: 1rem;
+
+  img {
+    height: 2.5rem;
+  }
 `;
 
 const SNSOptionContainer = styled.div`

--- a/src/components/PostNew/Step2/SelectAge/SelectAge.tsx
+++ b/src/components/PostNew/Step2/SelectAge/SelectAge.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { AgeBoxProps } from '../../../../types/PostNew';
-import { useOnboardingContext } from '../../../../context/PostNew/PonstNewContext';
+import { useOnboardingContext } from '../../../../context/PostNew/PostNewContext';
 
 export default function SelectAge() {
   const { onboardingInfo, updatePostInfo } = useOnboardingContext();

--- a/src/components/PostNew/Step2/SelectAge/SelectAge.tsx
+++ b/src/components/PostNew/Step2/SelectAge/SelectAge.tsx
@@ -1,16 +1,18 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { AgeBoxProps } from '../../../../types/PostNew';
+import { useOnboardingContext } from '../../../../context/PostNew/PonstNewContext';
 
 export default function SelectAge() {
-  const [selectedAges, setSelectedAges] = useState<string[]>([]);
+  const { onboardingInfo, updatePostInfo } = useOnboardingContext();
+  const [selectedAges, setSelectedAges] = useState<string[]>(onboardingInfo.targetAge || []);
 
   function toggleAge(age: string) {
-    if (selectedAges.includes(age)) {
-      setSelectedAges(selectedAges.filter((item) => item !== age));
-    } else {
-      setSelectedAges([...selectedAges, age]);
-    }
+    const updatedAges = selectedAges.includes(age)
+      ? selectedAges.filter((item) => item !== age)
+      : [...selectedAges, age];
+    setSelectedAges(updatedAges);
+    updatePostInfo({ targetAge: updatedAges });
   }
 
   const ageGroups = ['10대', '20대', '30대', '40대', '50대', '기타'];

--- a/src/components/PostNew/Step2/SelectGender/SelectGender.tsx
+++ b/src/components/PostNew/Step2/SelectGender/SelectGender.tsx
@@ -1,17 +1,23 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { GenderOptionProps } from '../../../../types/PostNew';
+import { useOnboardingContext } from '../../../../context/PostNew/PonstNewContext';
 
 export default function SelectGender() {
-  const [selectedGender, setSelectedGender] = useState<string | null>(null);
+  const { onboardingInfo, updatePostInfo } = useOnboardingContext();
+  const [selectedGender, setSelectedGender] = useState<string[]>(onboardingInfo.targetGender || []);
 
   function handleGenderSelect(gender: string) {
-    setSelectedGender(gender);
+    const updatedGender = selectedGender.includes(gender)
+      ? selectedGender.filter((item) => item !== gender)
+      : [...selectedGender, gender];
+    setSelectedGender(updatedGender);
+    updatePostInfo({ targetGender: updatedGender });
   }
 
   const genderOptions = [
-    { label: '남자', value: 'male', emoji: '🙋🏻‍♂️' },
-    { label: '여자', value: 'female', emoji: '🙋🏻‍♀️' },
+    { label: '남자', value: '남자', emoji: '🙋🏻‍♂️' },
+    { label: '여자', value: '여자', emoji: '🙋🏻‍♀️' },
   ];
 
   return (
@@ -19,7 +25,7 @@ export default function SelectGender() {
       {genderOptions.map((option) => (
         <GenderOption
           key={option.value}
-          selected={selectedGender === option.value}
+          selected={selectedGender.includes(option.value)}
           onClick={() => handleGenderSelect(option.value)}
         >
           <span role='img' aria-label={option.label} style={{ fontSize: '60px' }}>

--- a/src/components/PostNew/Step2/SelectGender/SelectGender.tsx
+++ b/src/components/PostNew/Step2/SelectGender/SelectGender.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { GenderOptionProps } from '../../../../types/PostNew';
-import { useOnboardingContext } from '../../../../context/PostNew/PonstNewContext';
+import { useOnboardingContext } from '../../../../context/PostNew/PostNewContext';
 
 export default function SelectGender() {
   const { onboardingInfo, updatePostInfo } = useOnboardingContext();

--- a/src/components/PostNew/Step2/Step2.tsx
+++ b/src/components/PostNew/Step2/Step2.tsx
@@ -1,19 +1,13 @@
-import PostFooter from '../PostFooter/PostFooter';
 import PostTitle from './PostTitle/PostTitle';
 import SelectAge from './SelectAge/SelectAge';
 import SelectGender from './SelectGender/SelectGender';
-interface NameInputProps {
-  onNext: VoidFunction;
-}
 
-export default function Step2(props: NameInputProps) {
-  const { onNext } = props;
+export default function Step2() {
   return (
     <>
       <PostTitle />
       <SelectGender />
       <SelectAge />
-      <PostFooter onNext={onNext} />
     </>
   );
 }

--- a/src/components/PostNew/Step3/SelectType/SelectType.tsx
+++ b/src/components/PostNew/Step3/SelectType/SelectType.tsx
@@ -15,8 +15,8 @@ export default function SelectType() {
   }
 
   const typeOptions = [
-    { label: '이벤트 홍보', value: 'event', emoji: '🎊' },
-    { label: '메뉴 홍보', value: 'menu', emoji: '📢' },
+    { label: '이벤트 홍보', value: '이벤트', emoji: '🎊' },
+    { label: '메뉴 홍보', value: '메뉴', emoji: '📢' },
   ];
 
   return (

--- a/src/components/PostNew/Step3/SelectType/SelectType.tsx
+++ b/src/components/PostNew/Step3/SelectType/SelectType.tsx
@@ -1,12 +1,17 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { GenderOptionProps } from '../../../../types/PostNew';
+import { useOnboardingContext } from '../../../../context/PostNew/PonstNewContext';
 
 export default function SelectType() {
-  const [selectedType, setSelectedType] = useState<string | null>(null);
+  const { onboardingInfo, updatePostInfo } = useOnboardingContext();
+  const [selectedType, setSelectedType] = useState<string | null>(
+    onboardingInfo.promotionType || null,
+  );
 
   function handleGenderSelect(type: string) {
     setSelectedType(type);
+    updatePostInfo({ promotionType: type });
   }
 
   const typeOptions = [
@@ -60,7 +65,6 @@ const TypeOption = styled.div<GenderOptionProps>`
   background: #fff;
   box-shadow: 1px 1px 13px 1px rgba(0, 0, 0, 0.07);
 
-  ${({ theme }) => theme.fonts.heading_01};
-  border: ${({ selected }) => (selected ? '1px solid #402FFF' : 'none')};
-  color: ${({ selected }) => (selected ? '#402FFF' : '#9D9D9D')};
+  ${({ theme, selected }) =>
+    selected ? `border: 1px solid ${theme.colors.main}; color: ${theme.colors.main}; ` : ''}
 `;

--- a/src/components/PostNew/Step3/SelectType/SelectType.tsx
+++ b/src/components/PostNew/Step3/SelectType/SelectType.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { GenderOptionProps } from '../../../../types/PostNew';
-import { useOnboardingContext } from '../../../../context/PostNew/PonstNewContext';
+import { useOnboardingContext } from '../../../../context/PostNew/PostNewContext';
 
 export default function SelectType() {
   const { onboardingInfo, updatePostInfo } = useOnboardingContext();

--- a/src/components/PostNew/Step3/Step3.tsx
+++ b/src/components/PostNew/Step3/Step3.tsx
@@ -1,13 +1,8 @@
 import styled from 'styled-components';
-import PostFooter from '../PostFooter/PostFooter';
 import SelectType from './SelectType/SelectType';
 import Title from '../../common/Title/Title';
-interface NameInputProps {
-  onNext: VoidFunction;
-}
 
-export default function Step3(props: NameInputProps) {
-  const { onNext } = props;
+export default function Step3() {
   return (
     <>
       <PostTitleContainer>
@@ -21,7 +16,6 @@ export default function Step3(props: NameInputProps) {
       </PostTitleContainer>
 
       <SelectType />
-      <PostFooter onNext={onNext} />
     </>
   );
 }

--- a/src/components/PostNew/Step4/Step4.tsx
+++ b/src/components/PostNew/Step4/Step4.tsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 import Title from '../../common/Title/Title';
 import { Xmark } from '../../../assets/svg';
-import useNameInput from '../../../hooks/PostNew/useMenuInput';
+import useMenuInput from '../../../hooks/PostNew/useMenuInput';
 
 export default function Step4() {
-  const { onboardingInfo, handleInputChange, handleBtnClick } = useNameInput();
+  const { onboardingInfo, handleInputChange } = useMenuInput();
+  const hasContent = onboardingInfo.promotionSubject.length > 0;
 
   return (
     <>
@@ -16,7 +17,7 @@ export default function Step4() {
       </PostTitleContainer>
 
       <MenuInputContainer>
-        <InputFieldContainer>
+        <InputFieldContainer $hasContent={hasContent}>
           <InputField
             type='text'
             value={onboardingInfo.promotionSubject}
@@ -24,10 +25,7 @@ export default function Step4() {
             placeholder='메뉴를 입력해주세요'
           />
           {onboardingInfo.promotionSubject && (
-            <Xmark
-              onClick={handleBtnClick}
-              style={{ width: '1rem', position: 'absolute', right: '5%' }}
-            />
+            <Xmark style={{ width: '1rem', position: 'absolute', right: '5%' }} />
           )}
         </InputFieldContainer>
         <Example>ex&#41; 소동 떡볶이 &#40;매운맛&#41;</Example>
@@ -70,7 +68,7 @@ export const Example = styled.div`
   ${({ theme }) => theme.fonts.ex_01};
 `;
 
-const InputFieldContainer = styled.div`
+const InputFieldContainer = styled.div<{ $hasContent: boolean }>`
   display: flex;
   align-items: center;
   position: relative;

--- a/src/components/PostNew/Step4/Step4.tsx
+++ b/src/components/PostNew/Step4/Step4.tsx
@@ -1,25 +1,10 @@
-import { useState } from 'react';
 import styled from 'styled-components';
-import PostFooter from '../PostFooter/PostFooter';
 import Title from '../../common/Title/Title';
 import { Xmark } from '../../../assets/svg';
+import useNameInput from '../../../hooks/PostNew/useMenuInput';
 
-interface NameInputProps {
-  onNext: VoidFunction;
-}
-
-export default function Step4(props: NameInputProps) {
-  const { onNext } = props;
-  const [menu, setMenu] = useState('');
-  const [price, setPrice] = useState('');
-
-  const handleMenuClear = () => {
-    setMenu('');
-  };
-
-  const handlePriceClear = () => {
-    setPrice('');
-  };
+export default function Step4() {
+  const { onboardingInfo, handleInputChange, handleBtnClick } = useNameInput();
 
   return (
     <>
@@ -34,13 +19,13 @@ export default function Step4(props: NameInputProps) {
         <InputFieldContainer>
           <InputField
             type='text'
-            value={menu}
-            onChange={(e) => setMenu(e.target.value)}
+            value={onboardingInfo.promotionSubject}
+            onChange={handleInputChange}
             placeholder='메뉴를 입력해주세요'
           />
-          {menu && (
+          {onboardingInfo.promotionSubject && (
             <Xmark
-              onClick={handleMenuClear}
+              onClick={handleBtnClick}
               style={{ width: '1rem', position: 'absolute', right: '5%' }}
             />
           )}
@@ -48,7 +33,7 @@ export default function Step4(props: NameInputProps) {
         <Example>ex&#41; 소동 떡볶이 &#40;매운맛&#41;</Example>
       </MenuInputContainer>
 
-      <PriceInputContainer>
+      {/* <PriceInputContainer>
         <InputFieldContainer>
           <InputField
             type='text'
@@ -64,9 +49,7 @@ export default function Step4(props: NameInputProps) {
           )}
         </InputFieldContainer>
         <Example>4500원</Example>
-      </PriceInputContainer>
-
-      <PostFooter onNext={onNext} />
+      </PriceInputContainer> */}
     </>
   );
 }
@@ -78,11 +61,6 @@ const PostTitleContainer = styled.div`
 
 const MenuInputContainer = styled.div`
   margin-top: 2rem;
-  position: relative;
-`;
-
-const PriceInputContainer = styled.div`
-  margin-top: 1rem;
   position: relative;
 `;
 
@@ -113,3 +91,8 @@ const InputField = styled.input`
 const Highlight = styled.span`
   color: ${({ theme }) => theme.colors.main};
 `;
+
+// const PriceInputContainer = styled.div`
+//   margin-top: 1rem;
+//   position: relative;
+// `;

--- a/src/components/PostNew/Step5/Step5.tsx
+++ b/src/components/PostNew/Step5/Step5.tsx
@@ -27,8 +27,7 @@ export default function Step5() {
 
       <ContentInputContainer>
         <ContentInput
-          type='text'
-          value={onboardingInfo.promotionSubject}
+          value={onboardingInfo.promotionContent}
           onChange={handleInputChange}
           placeholder='자세히 적을 수록 AI가 더 만족스러운 결과를 생성해요.'
         />
@@ -57,7 +56,7 @@ const ContentInputContainer = styled.div`
   margin-top: 2rem;
 `;
 
-const ContentInput = styled.input`
+const ContentInput = styled.textarea`
   width: 100vw;
   height: auto;
   min-height: 130px;

--- a/src/components/PostNew/Step5/Step5.tsx
+++ b/src/components/PostNew/Step5/Step5.tsx
@@ -1,26 +1,19 @@
-import React, { useState } from 'react';
 import styled from 'styled-components';
-import PostFooter from '../PostFooter/PostFooter';
 import Title from '../../common/Title/Title';
 import { Xmark } from '../../../assets/svg';
 import Tip from './Tip/Tip';
+import useMenuExplain from '../../../hooks/PostNew/useMenuExplain';
 
-interface NameInputProps {
-  onNext: VoidFunction;
-}
+export default function Step5() {
+  const { onboardingInfo, handleInputChange, handleBtnClick } = useMenuExplain();
 
-export default function Step5(props: NameInputProps) {
-  const { onNext } = props;
-  const [content, setContent] = useState('');
+  // const [content, setContent] = useState('');
 
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setContent(e.target.value);
-  };
-  const handleContentClear = () => {
-    setContent('');
-  };
+  // const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  //   setContent(e.target.value);
+  // };
 
-  const characterCount = content.length;
+  const characterCount = onboardingInfo.promotionSubject.length;
   const maxCharacters = 100;
 
   return (
@@ -34,14 +27,14 @@ export default function Step5(props: NameInputProps) {
 
       <ContentInputContainer>
         <ContentInput
-          value={content}
-          onChange={handleChange}
-          rows={1}
+          type='text'
+          value={onboardingInfo.promotionSubject}
+          onChange={handleInputChange}
           placeholder='자세히 적을 수록 AI가 더 만족스러운 결과를 생성해요.'
         />
-        {content && (
+        {onboardingInfo.promotionSubject && (
           <Xmark
-            onClick={handleContentClear}
+            onClick={handleBtnClick}
             style={{ width: '1.5rem', position: 'absolute', right: '13%', padding: '4% 0' }}
           />
         )}
@@ -50,7 +43,6 @@ export default function Step5(props: NameInputProps) {
         {characterCount}/{maxCharacters}
       </CharacterCount>
       <Tip />
-      <PostFooter onNext={onNext} />
     </>
   );
 }
@@ -65,7 +57,7 @@ const ContentInputContainer = styled.div`
   margin-top: 2rem;
 `;
 
-const ContentInput = styled.textarea`
+const ContentInput = styled.input`
   width: 100vw;
   height: auto;
   min-height: 130px;

--- a/src/components/PostNew/Step5/Step5.tsx
+++ b/src/components/PostNew/Step5/Step5.tsx
@@ -6,13 +6,6 @@ import useMenuExplain from '../../../hooks/PostNew/useMenuExplain';
 
 export default function Step5() {
   const { onboardingInfo, handleInputChange, handleBtnClick } = useMenuExplain();
-
-  // const [content, setContent] = useState('');
-
-  // const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-  //   setContent(e.target.value);
-  // };
-
   const characterCount = onboardingInfo.promotionSubject.length;
   const maxCharacters = 100;
 

--- a/src/components/PostNew/Step6/Step6.tsx
+++ b/src/components/PostNew/Step6/Step6.tsx
@@ -42,7 +42,7 @@ export default function Step6() {
       if (response.status === 200) {
         setSelectedFile(fileNameString);
         console.log('파일 업로드 성공' + selectedFile);
-        updatePostInfo({ fileName: fileNameString });
+        updatePostInfo({ fileName: fileNameString, postingType: 'Both' });
       } else {
         console.error('파일 업로드 실패');
       }

--- a/src/components/PostNew/Step6/Step6.tsx
+++ b/src/components/PostNew/Step6/Step6.tsx
@@ -15,33 +15,37 @@ interface NameInputProps {
 
 export default function Step6(props: NameInputProps) {
   const { setUserId } = props;
-  const { mutation } = usePostOnboardingInfo();
-  const { onboardingInfo } = useOnboardingContext();
+
+  // const { mutation } = usePostOnboardingInfo();
+  // const { onboardingInfo } = useOnboardingContext();
   const [previewImage, setPreviewImage] = useState<string | null>(null);
 
-  const postOnboarding = async () => {
-    try {
-      const response = mutation.mutate(onboardingInfo, {
-        onSuccess: (data) => {
-          console.log('step06 postOnboarding response', response);
-          const userId = data.userId;
-          setUserId(userId);
+  // const postOnboarding = async () => {
+  //   try {
+  //     const response = mutation.mutate(onboardingInfo, {
+  //       onSuccess: (data) => {
+  //         console.log('step06 postOnboarding response', response);
+  //         const userId = data.userId;
+  //         setUserId(userId);
 
-          return userId;
-        },
-      });
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  //         return userId;
+  //       },
+  //     });
+  //   } catch (error) {
+  //     console.log(error);
+  //   }
+  // };
 
-  const uploadFile = async (file: File, fileExtension: string) => {
+  const uploadFile = async (file: File) => {
     const formData = new FormData();
+    const fileExtension = `.${file.name.split('.').pop()}`;
+
     formData.append('file_content', file); // 파일 추가
 
     try {
       const queryParams = new URLSearchParams();
       queryParams.append('file_extension', fileExtension);
+      console.log('으으음??' + queryParams);
       const response = await put(`/api/ibm/object?${queryParams.toString()}`, formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
@@ -63,8 +67,8 @@ export default function Step6(props: NameInputProps) {
     if (files && files.length > 0) {
       const selectedFiles = files as FileList;
       const file = selectedFiles[0];
-      const fileExtension = '.jpeg'; // 파일 확장자 설정
-      uploadFile(file, fileExtension); // 파일 업로드 함수 호출
+
+      uploadFile(file); // 파일 업로드 함수 호출
       setPreviewImage(URL.createObjectURL(file));
     }
   };
@@ -83,7 +87,7 @@ export default function Step6(props: NameInputProps) {
       <IcEmptyThumbnailWrapper>
         <input
           type='file'
-          accept='image/jpeg, image/png, image/gif, image/heic '
+          accept='image/jpeg, image/png, image/gif, image/heic'
           style={{ display: 'none' }}
           id='imgInput'
           onChange={handleImageUpload}
@@ -115,13 +119,7 @@ export default function Step6(props: NameInputProps) {
         </ImgWrapper>
       </TipImageContainer>
 
-      <button
-        onClick={() => {
-          postOnboarding();
-        }}
-      >
-        으아
-      </button>
+      <UploadButton>업로드</UploadButton>
     </>
   );
 }
@@ -182,7 +180,7 @@ const SubTitle = styled.p`
   ${({ theme }) => theme.fonts.subTitle};
 `;
 
-export const IcEmptyThumbnailWrapper = styled.div`
+const IcEmptyThumbnailWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -192,10 +190,25 @@ export const IcEmptyThumbnailWrapper = styled.div`
   cursor: pointer;
 `;
 
-export const PreviewImg = styled.img`
+const PreviewImg = styled.img`
   width: 15rem;
   height: 15rem;
   border-radius: 10px;
   object-fit: contain;
   z-index: 9;
+`;
+
+const UploadButton = styled.button`
+  margin-top: 1rem;
+  background-color: ${({ theme }) => theme.colors.primary};
+  color: ${({ theme }) => theme.colors.white};
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.3s;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.primaryDark};
+  }
 `;

--- a/src/components/PostNew/Step6/Step6.tsx
+++ b/src/components/PostNew/Step6/Step6.tsx
@@ -7,12 +7,18 @@ import food3 from '../../../assets/Image/food3.jpg';
 import { IcEmptyThumbnailFinal, TipBtn } from '../../../assets/svg';
 import { put } from '../../../apis/client';
 import { useOnboardingContext } from '../../../context/PostNew/PostNewContext';
+import usePostOnboardingInfo from '../../../queries/PostNew/usePostInfo';
 
 interface ServerResponse {
   file_name: string;
 }
 
 export default function Step6() {
+  // const userId = localStorage.getItem('userId');
+  // const storeId = localStorage.getItem('storId');
+  // const parsedUserId = userId ? parseInt(userId, 10) : undefined;
+  // const parsedStoreId = storeId ? parseInt(storeId, 10) : undefined;
+
   const { updatePostInfo } = useOnboardingContext();
   const [previewImage, setPreviewImage] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
@@ -42,7 +48,7 @@ export default function Step6() {
       if (response.status === 200) {
         setSelectedFile(fileNameString);
         console.log('파일 업로드 성공' + selectedFile);
-        updatePostInfo({ fileName: fileNameString, postingType: 'Both' });
+        updatePostInfo({ fileName: fileNameString, postingType: 'Both', userId: 1, storeId: 1 });
       } else {
         console.error('파일 업로드 실패');
       }
@@ -59,6 +65,24 @@ export default function Step6() {
 
       uploadFile(file);
       setPreviewImage(URL.createObjectURL(file));
+    }
+  };
+
+  const { mutation } = usePostOnboardingInfo();
+  const { onboardingInfo } = useOnboardingContext();
+
+  const postOnboarding = async () => {
+    try {
+      const response = mutation.mutate(onboardingInfo, {
+        onSuccess: (data) => {
+          console.log('step06 postOnboarding response', response);
+          const userId = data.userId;
+
+          return userId;
+        },
+      });
+    } catch (error) {
+      console.log(error);
     }
   };
 
@@ -108,7 +132,7 @@ export default function Step6() {
         </ImgWrapper>
       </TipImageContainer>
 
-      <UploadButton>업로드</UploadButton>
+      <UploadButton onClick={postOnboarding}>업로드</UploadButton>
     </>
   );
 }
@@ -189,6 +213,8 @@ const PreviewImg = styled.img`
 
 const UploadButton = styled.button`
   margin-top: 1rem;
+  position: absolute;
+  z-index: 9;
   background-color: ${({ theme }) => theme.colors.primary};
   color: ${({ theme }) => theme.colors.white};
   padding: 0.5rem 1rem;

--- a/src/components/PostNew/Step6/Step6.tsx
+++ b/src/components/PostNew/Step6/Step6.tsx
@@ -6,17 +6,17 @@ import food2 from '../../../assets/Image/food2.jpg';
 import food3 from '../../../assets/Image/food3.jpg';
 import { IcEmptyThumbnailFinal, TipBtn } from '../../../assets/svg';
 import { put } from '../../../apis/client';
+import { useOnboardingContext } from '../../../context/PostNew/PostNewContext';
 
 interface ServerResponse {
   file_name: string;
 }
 
 export default function Step6() {
+  const { updatePostInfo } = useOnboardingContext();
   const [previewImage, setPreviewImage] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
 
-  // 1.
-  // IBM 서버 이미지 업로드 PUT 요청 함수
-  // 추후 react-query 리팩토링 예정
   const uploadFile = async (file: File) => {
     const formData = new FormData();
     const fileExtension = `.${file.name.split('.').pop()}`;
@@ -36,11 +36,13 @@ export default function Step6() {
         },
       );
 
-      const fileName = response.data.file_name;
-      console.log('image response: ' + fileName);
+      const fileNameString = response.data.file_name;
+      console.log('image response: ' + fileNameString);
 
       if (response.status === 200) {
-        console.log('파일 업로드 성공');
+        setSelectedFile(fileNameString);
+        console.log('파일 업로드 성공' + selectedFile);
+        updatePostInfo({ fileName: fileNameString });
       } else {
         console.error('파일 업로드 실패');
       }

--- a/src/components/PostNew/Step6/Step6.tsx
+++ b/src/components/PostNew/Step6/Step6.tsx
@@ -6,51 +6,38 @@ import food2 from '../../../assets/Image/food2.jpg';
 import food3 from '../../../assets/Image/food3.jpg';
 import { IcEmptyThumbnailFinal, TipBtn } from '../../../assets/svg';
 import { put } from '../../../apis/client';
-import usePostOnboardingInfo from '../../../queries/PostNew/usePostInfo';
-import { useOnboardingContext } from '../../../context/PostNew/PostNewContext';
 
-interface NameInputProps {
-  setUserId: React.Dispatch<React.SetStateAction<number>>;
+interface ServerResponse {
+  file_name: string;
 }
 
-export default function Step6(props: NameInputProps) {
-  const { setUserId } = props;
-
-  // const { mutation } = usePostOnboardingInfo();
-  // const { onboardingInfo } = useOnboardingContext();
+export default function Step6() {
   const [previewImage, setPreviewImage] = useState<string | null>(null);
 
-  // const postOnboarding = async () => {
-  //   try {
-  //     const response = mutation.mutate(onboardingInfo, {
-  //       onSuccess: (data) => {
-  //         console.log('step06 postOnboarding response', response);
-  //         const userId = data.userId;
-  //         setUserId(userId);
-
-  //         return userId;
-  //       },
-  //     });
-  //   } catch (error) {
-  //     console.log(error);
-  //   }
-  // };
-
+  // 1.
+  // IBM 서버 이미지 업로드 PUT 요청 함수
+  // 추후 react-query 리팩토링 예정
   const uploadFile = async (file: File) => {
     const formData = new FormData();
     const fileExtension = `.${file.name.split('.').pop()}`;
-
-    formData.append('file_content', file); // 파일 추가
+    formData.append('file_content', file);
 
     try {
       const queryParams = new URLSearchParams();
       queryParams.append('file_extension', fileExtension);
-      console.log('으으음??' + queryParams);
-      const response = await put(`/api/ibm/object?${queryParams.toString()}`, formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
+
+      const response = await put<ServerResponse>(
+        `/api/ibm/object?${queryParams.toString()}`,
+        formData,
+        {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
         },
-      });
+      );
+
+      const fileName = response.data.file_name;
+      console.log('image response: ' + fileName);
 
       if (response.status === 200) {
         console.log('파일 업로드 성공');
@@ -68,7 +55,7 @@ export default function Step6(props: NameInputProps) {
       const selectedFiles = files as FileList;
       const file = selectedFiles[0];
 
-      uploadFile(file); // 파일 업로드 함수 호출
+      uploadFile(file);
       setPreviewImage(URL.createObjectURL(file));
     }
   };

--- a/src/components/PostNew/Step6/Step6.tsx
+++ b/src/components/PostNew/Step6/Step6.tsx
@@ -7,7 +7,7 @@ import food3 from '../../../assets/Image/food3.jpg';
 import { IcEmptyThumbnailFinal, TipBtn } from '../../../assets/svg';
 import { put } from '../../../apis/client';
 import usePostOnboardingInfo from '../../../queries/PostNew/usePostInfo';
-import { useOnboardingContext } from '../../../context/PostNew/PonstNewContext';
+import { useOnboardingContext } from '../../../context/PostNew/PostNewContext';
 
 interface NameInputProps {
   setUserId: React.Dispatch<React.SetStateAction<number>>;

--- a/src/context/PostNew/PonstNewContext.tsx
+++ b/src/context/PostNew/PonstNewContext.tsx
@@ -1,63 +1,56 @@
-import {
-  PropsWithChildren,
-  SetStateAction,
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
-import { OnboardingInfo } from '../../types/PostNew';
+import { PropsWithChildren, createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { PostInfo } from '../../types/PostNew';
 
 interface OnboardingInfoContext {
-  onboardingInfo: OnboardingInfo;
-  updateOnboardingInfo: (newInfo: Partial<OnboardingInfo>) => void;
-  selectedTime: string;
-  setSelectedTime: React.Dispatch<SetStateAction<string>>;
+  onboardingInfo: PostInfo;
+  updatePostInfo: (newInfo: Partial<PostInfo>) => void;
+  updatePostingChannel: (sns: string | null) => void; // PostingChannel을 업데이트하는 함수 추가
 }
 
-const initialOnboardingInfo: OnboardingInfo = {
-  sns: '',
-  age: [],
-  gender: [],
-  type: '',
-  subject: '',
-  content: '',
-  imageUrl: '',
+const initialOnboardingInfo: PostInfo = {
+  userId: 0,
+  storeId: 0,
+  postingType: '',
+  postingChannel: '',
+  promotionType: '',
+  promotionSubject: '',
+  promotionContent: '',
+  fileName: '',
+  targetGender: [],
+  targetAge: [],
 };
 
 const OnboardingContext = createContext<OnboardingInfoContext>({
   onboardingInfo: initialOnboardingInfo,
-  updateOnboardingInfo: () => {},
-  selectedTime: '',
-  setSelectedTime: () => {},
+  updatePostInfo: () => {},
+  updatePostingChannel: () => {}, // 초기값 설정
 });
 
 export const useOnboardingContext = () => useContext(OnboardingContext);
 
 export const OnboardingProvider = ({ children }: PropsWithChildren) => {
-  const [onboardingInfo, setOnboardingInfo] = useState<OnboardingInfo>(initialOnboardingInfo);
-  const [selectedTime, setSelectedTime] = useState<string>('');
+  const [onboardingInfo, setOnboardingInfo] = useState<PostInfo>(initialOnboardingInfo);
 
-  const updateOnboardingInfo = (newInfo: Partial<OnboardingInfo>) => {
+  const updatePostInfo = (newInfo: Partial<PostInfo>) => {
     setOnboardingInfo((prev) => ({ ...prev, ...newInfo }));
   };
+
+   const updatePostingChannel = (sns: string | null) => {
+     setOnboardingInfo((prev) => ({ ...prev, postingChannel: sns }));
+   };
 
   /**@todo 전체 값 확인용 useEffect */
   useEffect(() => {
     console.log('전체 값 확인:', onboardingInfo);
-    console.log('context 속 selectedTime', selectedTime);
-    console.log('context 속 typeof selectedTime', typeof selectedTime);
-  }, [onboardingInfo, selectedTime]);
+  }, [onboardingInfo]);
 
   const OnboardingInfoContextValue = useMemo(
     () => ({
       onboardingInfo,
-      updateOnboardingInfo,
-      selectedTime,
-      setSelectedTime,
+      updatePostInfo,
+      updatePostingChannel,
     }),
-    [onboardingInfo, selectedTime],
+    [onboardingInfo],
   );
 
   return (

--- a/src/context/PostNew/PostNewContext.tsx
+++ b/src/context/PostNew/PostNewContext.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, createContext, useContext, useMemo, useState } from 'react';
+import { PropsWithChildren, createContext, useContext,  useMemo, useState } from 'react';
 import { PostInfo, PostInfoContext } from '../../types/PostNew';
 
 // 1.
@@ -6,7 +6,7 @@ import { PostInfo, PostInfoContext } from '../../types/PostNew';
 export const initialOnboardingInfo: PostInfo = {
   userId: 0,
   storeId: 0,
-  postingType: '',
+  postingType: 'Text',
   postingChannel: '',
   promotionType: '',
   promotionSubject: '',

--- a/src/context/PostNew/PostNewContext.tsx
+++ b/src/context/PostNew/PostNewContext.tsx
@@ -1,11 +1,8 @@
-import { PropsWithChildren, createContext, useContext, useEffect, useMemo, useState } from 'react';
-import { PostInfo } from '../../types/PostNew';
+import { PropsWithChildren, createContext, useContext, useMemo, useState } from 'react';
+import { PostInfo, PostInfoContext } from '../../types/PostNew';
 
-interface PostInfoContext {
-  onboardingInfo: PostInfo;
-  updatePostInfo: (newInfo: Partial<PostInfo>) => void;
-}
-
+// 1.
+// [포스트 생성] 관리해야하는 상태 값 초기화
 export const initialOnboardingInfo: PostInfo = {
   userId: 0,
   storeId: 0,
@@ -19,25 +16,32 @@ export const initialOnboardingInfo: PostInfo = {
   targetAge: [],
 };
 
+// 2.
+// [포스트 생성] Context api 생성
 const OnboardingContext = createContext<PostInfoContext>({
   onboardingInfo: initialOnboardingInfo,
   updatePostInfo: () => {},
 });
 
+// 3.
+// 커스텀 훅 분리
 export const useOnboardingContext = () => useContext(OnboardingContext);
 
+// 4.
+// provider 컴포넌트 생성
 export const OnboardingProvider = ({ children }: PropsWithChildren) => {
   const [onboardingInfo, setOnboardingInfo] = useState<PostInfo>(initialOnboardingInfo);
 
+  // 4-1.
+  // onboardingInfo 객체를 업데이트하는 함수
+  // 부분적인 정보를 업데이트 가능 -> Partial 사용
   const updatePostInfo = (newInfo: Partial<PostInfo>) => {
     setOnboardingInfo((prev) => ({ ...prev, ...newInfo }));
   };
 
-  /**@todo 전체 값 확인용 useEffect */
-  useEffect(() => {
-    console.log('전체 값 확인:', onboardingInfo);
-  }, [onboardingInfo]);
-
+  // 4-2.
+  // OnboardingContext.Provider의 value 속성으로 제공
+  // 하위 컴포넌트에서 컨텍스트를 통해 onboardingInfo 상태와 updatePostInfo 함수에 접근
   const OnboardingInfoContextValue = useMemo(
     () => ({
       onboardingInfo,

--- a/src/context/PostNew/PostNewContext.tsx
+++ b/src/context/PostNew/PostNewContext.tsx
@@ -1,13 +1,12 @@
 import { PropsWithChildren, createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { PostInfo } from '../../types/PostNew';
 
-interface OnboardingInfoContext {
+interface PostInfoContext {
   onboardingInfo: PostInfo;
   updatePostInfo: (newInfo: Partial<PostInfo>) => void;
-  updatePostingChannel: (sns: string | null) => void; // PostingChannel을 업데이트하는 함수 추가
 }
 
-const initialOnboardingInfo: PostInfo = {
+export const initialOnboardingInfo: PostInfo = {
   userId: 0,
   storeId: 0,
   postingType: '',
@@ -20,10 +19,9 @@ const initialOnboardingInfo: PostInfo = {
   targetAge: [],
 };
 
-const OnboardingContext = createContext<OnboardingInfoContext>({
+const OnboardingContext = createContext<PostInfoContext>({
   onboardingInfo: initialOnboardingInfo,
   updatePostInfo: () => {},
-  updatePostingChannel: () => {}, // 초기값 설정
 });
 
 export const useOnboardingContext = () => useContext(OnboardingContext);
@@ -35,10 +33,6 @@ export const OnboardingProvider = ({ children }: PropsWithChildren) => {
     setOnboardingInfo((prev) => ({ ...prev, ...newInfo }));
   };
 
-   const updatePostingChannel = (sns: string | null) => {
-     setOnboardingInfo((prev) => ({ ...prev, postingChannel: sns }));
-   };
-
   /**@todo 전체 값 확인용 useEffect */
   useEffect(() => {
     console.log('전체 값 확인:', onboardingInfo);
@@ -48,7 +42,6 @@ export const OnboardingProvider = ({ children }: PropsWithChildren) => {
     () => ({
       onboardingInfo,
       updatePostInfo,
-      updatePostingChannel,
     }),
     [onboardingInfo],
   );

--- a/src/hooks/PostNew/useMenuExplain.tsx
+++ b/src/hooks/PostNew/useMenuExplain.tsx
@@ -3,7 +3,7 @@ import { useOnboardingContext } from '../../context/PostNew/PonstNewContext';
 const useMenuExplain = () => {
   const { onboardingInfo, updatePostInfo } = useOnboardingContext();
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     let inputValue = e.target.value;
     updatePostInfo({ promotionContent: inputValue });
   };

--- a/src/hooks/PostNew/useMenuExplain.tsx
+++ b/src/hooks/PostNew/useMenuExplain.tsx
@@ -1,0 +1,22 @@
+import { useOnboardingContext } from '../../context/PostNew/PonstNewContext';
+
+const useMenuExplain = () => {
+  const { onboardingInfo, updatePostInfo } = useOnboardingContext();
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let inputValue = e.target.value;
+    updatePostInfo({ promotionContent: inputValue });
+  };
+
+  const handleBtnClick = () => {
+    updatePostInfo({ promotionContent: '' });
+  };
+
+  return {
+    onboardingInfo,
+    handleInputChange,
+    handleBtnClick,
+  };
+};
+
+export default useMenuExplain;

--- a/src/hooks/PostNew/useMenuExplain.tsx
+++ b/src/hooks/PostNew/useMenuExplain.tsx
@@ -1,4 +1,4 @@
-import { useOnboardingContext } from '../../context/PostNew/PonstNewContext';
+import { useOnboardingContext } from '../../context/PostNew/PostNewContext';
 
 const useMenuExplain = () => {
   const { onboardingInfo, updatePostInfo } = useOnboardingContext();

--- a/src/hooks/PostNew/useMenuInput.tsx
+++ b/src/hooks/PostNew/useMenuInput.tsx
@@ -1,4 +1,4 @@
-import { useOnboardingContext } from '../../context/PostNew/PonstNewContext';
+import { useOnboardingContext } from '../../context/PostNew/PostNewContext';
 
 const useMenuInput = () => {
   const { onboardingInfo, updatePostInfo } = useOnboardingContext();

--- a/src/hooks/PostNew/useMenuInput.tsx
+++ b/src/hooks/PostNew/useMenuInput.tsx
@@ -1,27 +1,17 @@
 import { useOnboardingContext } from '../../context/PostNew/PonstNewContext';
 
-const useNameInput = () => {
+const useMenuInput = () => {
   const { onboardingInfo, updatePostInfo } = useOnboardingContext();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     let inputValue = e.target.value;
-
-    // 아이폰 특수문자 제거
-    const hasIphoneSpecialCharacter = /[\ud800-\udfff]/.test(inputValue);
-
-    if (hasIphoneSpecialCharacter) {
-      inputValue = inputValue.replace(/[\ud800-\udfff]/g, '');
-      updatePostInfo({ promotionSubject: inputValue });
-    } else {
-      updatePostInfo({ promotionSubject: inputValue });
-    }
+    updatePostInfo({ promotionSubject: inputValue });
   };
 
   const handleBtnClick = () => {
     updatePostInfo({ promotionSubject: '' });
   };
 
- 
   return {
     onboardingInfo,
     handleInputChange,
@@ -29,4 +19,4 @@ const useNameInput = () => {
   };
 };
 
-export default useNameInput;
+export default useMenuInput;

--- a/src/hooks/PostNew/useMenuInput.tsx
+++ b/src/hooks/PostNew/useMenuInput.tsx
@@ -1,0 +1,32 @@
+import { useOnboardingContext } from '../../context/PostNew/PonstNewContext';
+
+const useNameInput = () => {
+  const { onboardingInfo, updatePostInfo } = useOnboardingContext();
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let inputValue = e.target.value;
+
+    // 아이폰 특수문자 제거
+    const hasIphoneSpecialCharacter = /[\ud800-\udfff]/.test(inputValue);
+
+    if (hasIphoneSpecialCharacter) {
+      inputValue = inputValue.replace(/[\ud800-\udfff]/g, '');
+      updatePostInfo({ promotionSubject: inputValue });
+    } else {
+      updatePostInfo({ promotionSubject: inputValue });
+    }
+  };
+
+  const handleBtnClick = () => {
+    updatePostInfo({ promotionSubject: '' });
+  };
+
+ 
+  return {
+    onboardingInfo,
+    handleInputChange,
+    handleBtnClick,
+  };
+};
+
+export default useNameInput;

--- a/src/hooks/PostNew/useSnsSelect.tsx
+++ b/src/hooks/PostNew/useSnsSelect.tsx
@@ -1,25 +1,27 @@
 import { useOnboardingContext } from '../../context/PostNew/PonstNewContext';
 
 const useSnsSelect = () => {
-  const { onboardingInfo, updateOnboardingInfo } = useOnboardingContext();
+  const { onboardingInfo, updatePostInfo } = useOnboardingContext();
+  // const [selectedSNS, setSelectedSNS] = useState<string | null>(null);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  // const handleSnsSelect = (date: Date) => {
+  //   // const padTwoDigits = (value: number) => String(value).padStart(2, '0');
+
+  //   // const formattedDate = 'insta';
+  //   // updatePostInfo({ postingChannel: formattedDate });
+
+  //   // setSelectedDate(date);
+
+  // };
+  const handleSnsSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     let inputValue = e.target.value;
 
-    updateOnboardingInfo({ sns: inputValue });
+    updatePostInfo({ postingChannel: inputValue });
   };
-
-  const handleBtnClick = () => {
-    updateOnboardingInfo({ sns: '' });
-  };
-
-  const isActivated = onboardingInfo.sns.length > 0;
 
   return {
     onboardingInfo,
-    handleInputChange,
-    handleBtnClick,
-    isActivated,
+    handleSnsSelect,
   };
 };
 

--- a/src/hooks/PostNew/useSnsSelect.tsx
+++ b/src/hooks/PostNew/useSnsSelect.tsx
@@ -1,4 +1,4 @@
-import { useOnboardingContext } from '../../context/PostNew/PonstNewContext';
+import { useOnboardingContext } from '../../context/PostNew/PostNewContext';
 
 const useSnsSelect = () => {
   const { onboardingInfo, updatePostInfo } = useOnboardingContext();

--- a/src/pages/PostNew/PostNew.tsx
+++ b/src/pages/PostNew/PostNew.tsx
@@ -11,7 +11,7 @@ import ProcessBar from '../../components/common/ProcessBar/ProcessBar';
 import { useState } from 'react';
 import PostFooter from '../../components/PostNew/PostFooter/PostFooter';
 import { useNavigate } from 'react-router-dom';
-import { useOnboardingContext } from '../../context/PostNew/PonstNewContext';
+import { useOnboardingContext } from '../../context/PostNew/PostNewContext';
 
 export default function PostNew() {
   const navigate = useNavigate();

--- a/src/pages/PostNew/PostNew.tsx
+++ b/src/pages/PostNew/PostNew.tsx
@@ -8,7 +8,6 @@ import Step4 from '../../components/PostNew/Step4/Step4';
 import Step5 from '../../components/PostNew/Step5/Step5';
 import Step6 from '../../components/PostNew/Step6/Step6';
 import ProcessBar from '../../components/common/ProcessBar/ProcessBar';
-import { useState } from 'react';
 import PostFooter from '../../components/PostNew/PostFooter/PostFooter';
 import { useNavigate } from 'react-router-dom';
 import { useOnboardingContext } from '../../context/PostNew/PostNewContext';
@@ -16,10 +15,8 @@ import { useOnboardingContext } from '../../context/PostNew/PostNewContext';
 export default function PostNew() {
   const navigate = useNavigate();
   const { Funnel, setStep } = useFunnel(ONBOARDING_FORM_STEP, ONBOARDING_FORM_STEP[0]);
-  const [userId, setUserId] = useState<number>(0);
-  const { onboardingInfo, updatePostInfo } = useOnboardingContext();
 
-  console.log(userId);
+  const { onboardingInfo, updatePostInfo } = useOnboardingContext();
 
   // [이전 버튼]
   const onClickBackBtn = (stepNum: number) => {
@@ -98,7 +95,7 @@ export default function PostNew() {
       <Funnel.Step name='POSTING_IMAGE'>
         <PostNewContainer>
           <ProcessBar currentStep={6} stepCount={6} />
-          <Step6 setUserId={setUserId} />
+          <Step6 />
           <PostFooter
             onClickBackBtn={() => onClickBackBtn(6)}
             setStep={() => setStep(() => 'POSTING_IMAGE')}

--- a/src/pages/PostNew/PostNew.tsx
+++ b/src/pages/PostNew/PostNew.tsx
@@ -14,13 +14,13 @@ import { useNavigate } from 'react-router-dom';
 import { useOnboardingContext } from '../../context/PostNew/PonstNewContext';
 
 export default function PostNew() {
-   const navigate = useNavigate();
+  const navigate = useNavigate();
   const { Funnel, setStep } = useFunnel(ONBOARDING_FORM_STEP, ONBOARDING_FORM_STEP[0]);
   const [userId, setUserId] = useState<number>(0);
   const { onboardingInfo, updatePostInfo } = useOnboardingContext();
 
   console.log(userId);
-  
+
   // [이전 버튼]
   const onClickBackBtn = (stepNum: number) => {
     const stepIndex = stepNum - 1;

--- a/src/pages/PostNew/PostNew.tsx
+++ b/src/pages/PostNew/PostNew.tsx
@@ -8,51 +8,101 @@ import Step4 from '../../components/PostNew/Step4/Step4';
 import Step5 from '../../components/PostNew/Step5/Step5';
 import Step6 from '../../components/PostNew/Step6/Step6';
 import ProcessBar from '../../components/common/ProcessBar/ProcessBar';
+import { useState } from 'react';
+import PostFooter from '../../components/PostNew/PostFooter/PostFooter';
+import { useNavigate } from 'react-router-dom';
+import { useOnboardingContext } from '../../context/PostNew/PonstNewContext';
 
 export default function PostNew() {
+   const navigate = useNavigate();
   const { Funnel, setStep } = useFunnel(ONBOARDING_FORM_STEP, ONBOARDING_FORM_STEP[0]);
+  const [userId, setUserId] = useState<number>(0);
+  const { onboardingInfo, updatePostInfo } = useOnboardingContext();
+
+  console.log(userId);
   
+  // [이전 버튼]
+  const onClickBackBtn = (stepNum: number) => {
+    const stepIndex = stepNum - 1;
+    if (stepIndex === 0) {
+      navigate('/');
+    } else {
+      setStep(() => ONBOARDING_FORM_STEP[stepIndex - 1]);
+      updatePostInfo({
+        postingChannel: onboardingInfo.postingChannel,
+        promotionType: onboardingInfo.promotionType,
+        promotionSubject: onboardingInfo.promotionSubject,
+        promotionContent: onboardingInfo.promotionContent,
+        fileName: onboardingInfo.fileName,
+      });
+    }
+  };
+
   return (
     <Funnel>
       <Funnel.Step name='POSTING_CHANNEL'>
         <PostNewContainer>
           <ProcessBar currentStep={1} stepCount={6} />
-          <Step1 onNext={() => setStep(() => 'AGE_GENDER')} />
+          <Step1 />
+          <PostFooter
+            onClickBackBtn={() => onClickBackBtn(1)}
+            setStep={() => setStep(() => 'AGE_GENDER')}
+          />
         </PostNewContainer>
       </Funnel.Step>
 
       <Funnel.Step name='AGE_GENDER'>
         <PostNewContainer>
           <ProcessBar currentStep={2} stepCount={6} />
-          <Step2 onNext={() => setStep(() => 'TYPE')} />
+          <Step2 />
+          <PostFooter
+            onClickBackBtn={() => onClickBackBtn(2)}
+            setStep={() => setStep(() => 'TYPE')}
+          />
         </PostNewContainer>
       </Funnel.Step>
 
       <Funnel.Step name='TYPE'>
         <PostNewContainer>
           <ProcessBar currentStep={3} stepCount={6} />
-          <Step3 onNext={() => setStep(() => 'POSTING_SUBJECT')} />
+          <Step3 />
+          <PostFooter
+            onClickBackBtn={() => onClickBackBtn(3)}
+            setStep={() => setStep(() => 'POSTING_SUBJECT')}
+          />
         </PostNewContainer>
       </Funnel.Step>
 
       <Funnel.Step name='POSTING_SUBJECT'>
         <PostNewContainer>
           <ProcessBar currentStep={4} stepCount={6} />
-          <Step4 onNext={() => setStep(() => 'POSTING_CONTENT')} />
+          <Step4 />
+          <PostFooter
+            onClickBackBtn={() => onClickBackBtn(4)}
+            setStep={() => setStep(() => 'POSTING_CONTENT')}
+          />
         </PostNewContainer>
       </Funnel.Step>
 
       <Funnel.Step name='POSTING_CONTENT'>
         <PostNewContainer>
           <ProcessBar currentStep={5} stepCount={6} />
-          <Step5 onNext={() => setStep(() => 'POSTING_IMAGE')} />
+          <Step5 />
+          <PostFooter
+            onClickBackBtn={() => onClickBackBtn(5)}
+            setStep={() => setStep(() => 'POSTING_IMAGE')}
+          />
         </PostNewContainer>
       </Funnel.Step>
 
       <Funnel.Step name='POSTING_IMAGE'>
         <PostNewContainer>
           <ProcessBar currentStep={6} stepCount={6} />
-          <Step6 onNext={() => setStep(() => 'POSTING_IMAGE')} />
+          <Step6 setUserId={setUserId} />
+          <PostFooter
+            onClickBackBtn={() => onClickBackBtn(6)}
+            setStep={() => setStep(() => 'POSTING_IMAGE')}
+          />
         </PostNewContainer>
       </Funnel.Step>
     </Funnel>

--- a/src/queries/PostNew/usePostInfo.tsx
+++ b/src/queries/PostNew/usePostInfo.tsx
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+import { post } from '../../apis/client';
+import { PostInfo } from '../../types/PostNew';
+
+interface PostOnboardingInfoRes {
+  userId: number;
+  storeId: number;
+  postingId: number;
+}
+
+const postOnboardingInfo = async (postInfo: PostInfo) => {
+  const response = await post<PostOnboardingInfoRes>(`/posting`, postInfo);
+  return response.data;
+};
+
+const usePostOnboardingInfo = () => {
+  const mutation = useMutation({
+    mutationFn: postOnboardingInfo,
+    onSuccess: (data) => {
+      console.log('포스팅 생성 성공?', data);
+    },
+  });
+
+  return { mutation };
+};
+export default usePostOnboardingInfo;

--- a/src/queries/PostNew/usePostInfo.tsx
+++ b/src/queries/PostNew/usePostInfo.tsx
@@ -9,7 +9,7 @@ interface PostOnboardingInfoRes {
 }
 
 const postOnboardingInfo = async (postInfo: PostInfo) => {
-  const response = await post<PostOnboardingInfoRes>(`/posting`, postInfo);
+  const response = await post<PostOnboardingInfoRes>(`/api/posting`, postInfo);
   return response.data;
 };
 

--- a/src/queries/PostNew/useUploadImage.tsx
+++ b/src/queries/PostNew/useUploadImage.tsx
@@ -1,0 +1,49 @@
+// import { useMutation, useQueryClient } from '@tanstack/react-query';
+// import { post } from '../../apis/client';
+// import { ImageUploadRequestType } from '../../types/PostNew';
+// import { useNavigate } from 'react-router-dom';
+
+// interface PostGiftProps {
+//   file_extension: string;
+//   file_content: string;
+// }
+
+// export interface ImageUploadRequestType {
+//   file_extension: string;
+//   file_content: string;
+// }
+
+// export const uploadImage = async (body: ImageUploadRequestType) => {
+//   try {
+//     const response = await post(`/ibm/object`, body);
+//     console.log('response data', response.data);
+//     return response.data;
+//   } catch (error: any) {
+//     console.log('확인확인', error.message);
+//     if (error.message === '중복된 선물 등록입니다.') {
+//       console.log('들어와~', error);
+//       throw new Error(`${error}`);
+//     }
+//   }
+// };
+
+// export const usePostGift = ({ file_content, file_extension }: PostGiftProps) => {
+//   const navigate = useNavigate();
+
+//   const queryClient = useQueryClient();
+
+//   const mutation = useMutation({
+//     mutationFn: uploadImage,
+//     onSuccess: () => {
+//       console.log('선물 등록 성공!!');
+//       queryClient.invalidateQueries({ queryKey: [MY_GIFT_QUERY_KEY[0], roomId] });
+//     },
+//     onError: (error) => {
+//       console.log('선물 등록 에러!!', error.message);
+//     },
+//   });
+
+//   return { mutation };
+// };
+
+// export default usePostGift;

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -9,6 +9,7 @@ import StoreHeaderLayout from '../layouts/StoreHeaderLayout';
 import Login from '../pages/Login/Login';
 import StoreNew from '../pages/StoreNew/StoreNew';
 import PostHistoryPage from '../pages/PostHistory/PostHistoryPage';
+import { OnboardingProvider } from '../context/PostNew/PonstNewContext';
 
 const router = createBrowserRouter([
   {
@@ -33,7 +34,11 @@ const router = createBrowserRouter([
         children: [
           {
             path: '/post',
-            element: <PostNew />,
+            element: (
+              <OnboardingProvider>
+                <PostNew />
+              </OnboardingProvider>
+            ),
           },
         ],
       },

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -9,7 +9,7 @@ import StoreHeaderLayout from '../layouts/StoreHeaderLayout';
 import Login from '../pages/Login/Login';
 import StoreNew from '../pages/StoreNew/StoreNew';
 import PostHistoryPage from '../pages/PostHistory/PostHistoryPage';
-import { OnboardingProvider } from '../context/PostNew/PonstNewContext';
+import { OnboardingProvider } from '../context/PostNew/PostNewContext';
 
 const router = createBrowserRouter([
   {

--- a/src/types/PostNew/index.d.ts
+++ b/src/types/PostNew/index.d.ts
@@ -19,8 +19,8 @@ export interface GenderOptionProps {
 }
 
 export type PostInfo = {
-  userId: number;
-  storeId: number;
+  userId: number | undefined;
+  storeId: number | undefined;
   postingType: string;
   postingChannel: string | null;
   promotionType: string;

--- a/src/types/PostNew/index.d.ts
+++ b/src/types/PostNew/index.d.ts
@@ -18,12 +18,20 @@ export interface GenderOptionProps {
   selected: boolean;
 }
 
-export type OnboardingInfo = {
-  sns: string;
-  age: Array;
-  gender: Array;
-  type: string;
-  subject: string;
-  content: string;
-  imageUrl?: string;
+export type PostInfo = {
+  userId: number;
+  storeId: number;
+  postingType: string;
+  postingChannel: string | null;
+  promotionType: string;
+  promotionSubject: string;
+  promotionContent: string;
+  fileName: string;
+  targetGender: Array;
+  targetAge: Array;
 };
+
+export interface ImageUploadRequestType {
+  file_extension: string;
+  file_content: string;
+}

--- a/src/types/PostNew/index.d.ts
+++ b/src/types/PostNew/index.d.ts
@@ -26,7 +26,7 @@ export type PostInfo = {
   promotionType: string;
   promotionSubject: string;
   promotionContent: string;
-  fileName: string;
+  fileName: string | null;
   targetGender: Array;
   targetAge: Array;
 };

--- a/src/types/PostNew/index.d.ts
+++ b/src/types/PostNew/index.d.ts
@@ -35,3 +35,8 @@ export interface ImageUploadRequestType {
   file_extension: string;
   file_content: string;
 }
+
+export interface PostInfoContext {
+  onboardingInfo: PostInfo;
+  updatePostInfo: (newInfo: Partial<PostInfo>) => void;
+}


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 🪄 Issue Number
- close #30 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 🏆 Details
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x]  정보 폼데이터 받기
- [x]  Context API를 활용한 이전 버튼 값 저장
- [x] IBM 이미지 업로드 통신

## ✅ Need Review
>**이미지 업로드 통신 이유 :** 
client -> spring -> fastapi로 요청이 전달되는 구조인데 상대적으로 무거운 이미지 데이터를 계속 들고다니는 것보다 클라우드에 저장해놓고 URL 형태로 들고다니기 위함.
[이미지업로드 테스트 통과했는데도 cors 에러](https://spiny-lake-7e5.notion.site/e7805cbf20504c89af500b2dcaaecaa6?pvs=4)하면서 겪었던 CORS 에러 트러블 슈팅 노션 남겨두겠습니다. 

- state 업데이트를 위해 partial 타입 사용
<img width="410" alt="스크린샷 2024-03-21 오후 8 26 06" src="https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_27_FE/assets/104339899/0e543633-aeba-495d-ba25-d1cfa14a734a">

- 온보딩 과정 정리해서 말씀드리자면 앞서 말한 Funnel 패턴으로 여러 Steps를 한 페이지에서 관리하게 하였습니다. 
- 값들의 업데이트를 원활하게 진행시키기 위해 이전 버튼 클릭 시 눌렀던 값을 남기기 위해 context API를 활용했습니다. 
- preview 이미지는  `URL.createObjectURL(file));`함수를 써서 추후에 이슈를 판 후 이전 돌아갔다가 돌아와도 이미지가 남아있게 처리해두겠습니다 (동일하게 context사용하면 될 것 같습니다.)

### 유신님 `전역 상태 관리 라이브러리` 의견이 궁금해요 :
유신님이라면 한 페이지에서 상태를 관리를 해야될 때 상태관리 라이브러리에 의존하지 않고 더 좋은 방법이 있을까요? (제가 funnel에 대한 공부가 아직 깊지 않아서 생긴 문제일 수 도 있습니다!)
- Context API는 Provider 하위의 모든 consumer들이 Provider 속성이 변경될 때마다 다시 렌더링되는 단점이 있습니다. 그렇기에 만약 Provider의 값이 배열이나 객체인 경우, 구조가 조금이라도 변경된다면 그 Context를 구독하고 있는 하위의 모든 것들이 다시 렌더링되죠🥲 그럼에도 불구하고 제가 recoil이 아닌 context API 를 쓴 이유는 " context는 React 컴포넌트 트리 안에서 전역적(global)이라고 볼 수 있는 데이터를 공유할 수 있도록 고안된 방법입니다." 이여서 지역적 전역 변수로 활용하기 좋을 것 같아 conText를 활용했습니다. 

>결론 : 
넓은 범위에서 Recoil이 제공하는 기능이 좀 더 유용하지만 Context API는 간단히 Child에서 Parent로 State를 전달하는 기능에 중점을 두고 있어 작은 서비스에서 사용할 때 더 간단하고 가볍게 구현하기 좋을 것 같습니다. 이 의견에 어떻게 생각하시는지 궁금합니다~ 

<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 Screenshot
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_27_FE/assets/104339899/0470fb67-c86d-44da-bf58-af9262d936e2




## 📚 Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
